### PR TITLE
Update e2guardian.xml

### DIFF
--- a/pkg-e2guardian4/files/usr/local/pkg/e2guardian.xml
+++ b/pkg-e2guardian4/files/usr/local/pkg/e2guardian.xml
@@ -156,7 +156,7 @@
 			<fieldname>httpworkers</fieldname>
                         <type>input</type>
                         <size>10</size>
-                        <description><![CDATA[Default: <strong>100</strong><br>
+                        <description><![CDATA[Default: <strong>256</strong><br>
                                This figure is the maximum number of concurrent connections.<br>
                                If more connections are made, connections will queue until a worker thread is free.<br>
                                On large site you might want to try 2500 (max value 20000)<br>


### PR DESCRIPTION
Default HTTP workers were changed to 256, therefore it makes sense to update the XML to reflect the change.

Keep up the good work!