### PR TITLE
correção dos parametros de logs

### DIFF
--- a/pkg-squidanalyzer/files/usr/local/pkg/squidanalyzer.inc
+++ b/pkg-squidanalyzer/files/usr/local/pkg/squidanalyzer.inc
@@ -51,7 +51,7 @@ function validate_form_sa($post, &$input_errors) {
 		if ( $post['squidlog'] == "" ) {
 			$input_errors[] = gettext('The field') . " Squid Log " . gettext('cannot be empty');
 		} else {
-			$files = explode(" ",$post['squidlog']);
+			$files = explode(",",$post['squidlog']);
 			foreach ($files as $file) {
 				if (! file_exists($file)) {
 					$input_errors[] = "$file " . gettext ('does not exists');


### PR DESCRIPTION
os caminhos dos logs fornecidos pelo usuário na interface gráfica são dados separando-se por espaços.
proponho mudar isso e separar os caminhos dos logs por vírgulas, pois assim o valor da variável $settings['squidlog'] no arquivo squidanalyzer.template estará correto para execução e sem precisar de outros tratamentos.
Essa proposta de correção se deve ao fato de que o squidanalyzer necessita que os caminhos de logs sejam separados por vírgulas, mas na atual conjuntura eles estão indo para o arquivo de configuração separados por espaços.