### PR TITLE
correção dos caminhos de logs

### DIFF
--- a/pkg-squidanalyzer/files/usr/local/pkg/squidanalyzer.xml
+++ b/pkg-squidanalyzer/files/usr/local/pkg/squidanalyzer.xml
@@ -67,7 +67,7 @@
 	<field>
       		<fielddescr>Squid log</fielddescr>
       		<fieldname>squidlog</fieldname>
-      		<description>Set the path to the Squid/squidguard/e2guardian log file(s) separeted by space.</description>
+      		<description>Set the path to the Squid/squidguard/e2guardian log file(s) separeted by comma.</description>
       		<type>input</type>
       		<size>60</size>
       		<default_value>/var/squid/logs/access.log</default_value>


### PR DESCRIPTION
o squidanalyzer precisa que os caminhos de logs sejam separados por vírgulas, mas na atual conjuntura estão sendo salvos no arquivo de configuração separados por espaços.
minha proposta é que apenas se altere a forma como o usuário entra com as informações para corrigir o problema. Ademais, corrige-se também a linha 54 do arquivo squidanalyzer.inc para que a função $files = explode(" ",$post['squidlog']); para $files = explode(",",$post['squidlog']);