### PR TITLE
check variables before use for count and sizeof

### DIFF
--- a/pkg-e2guardian5/files/usr/local/pkg/e2guardian.inc
+++ b/pkg-e2guardian5/files/usr/local/pkg/e2guardian.inc
@@ -506,8 +506,8 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 	$logexceptionhits = ($e2guardian_log['logexceptionhits'] ? $e2guardian_log['logexceptionhits'] : "2");
 	$logfileformat = ($e2guardian_log['logfileformat'] ? $e2guardian_log['logfileformat'] : "1");
 	$logrotate = ($e2guardian_log['logrotate']  ? "on" : "off");
-	$cronminute = ($e2guardian_log['cronminute'] ? $e2guardian_log['cronminute'] : "*");
-	$cronhour = ($e2guardian_log['cronhour']  ? $e2guardian_log['cronhour'] : "*");
+	$cronminute = ($e2guardian_log['cronminute'] ? $e2guardian_log['cronminute'] : "0");
+	$cronhour = ($e2guardian_log['cronhour']  ? $e2guardian_log['cronhour'] : "0");
 	$logfilecount = ($e2guardian_log['logcount'] ? $e2guardian_log['logcount'] : "30");
 
 	

--- a/pkg-e2guardian5/files/usr/local/pkg/e2guardian.inc
+++ b/pkg-e2guardian5/files/usr/local/pkg/e2guardian.inc
@@ -1409,8 +1409,10 @@ break;
 				}
 			}
 		}
-		$filtergroup_count = count($import_users);
-		$filtergroupip_count = count($import_ips);
+		is_countable($import_users) ? $filtergroup_count = count($import_users) : $filtergroup_count=0;
+		is_countable($import_ips) ? $filtergroupip_count = count($import_ips) : $filtergroupip_count=0;
+// 		$filtergroup_count = count($import_users);
+// 		$filtergroupip_count = count($import_ips);
 		//Default group catch all unauth groups as well non listed users
 		if ($count > 1)
 		$user_xml .=<<<EOF
@@ -1903,7 +1905,7 @@ function e2guardian_validate_input($post, &$input_errors) {
 	    !in_array('reverseclientiplookups', $post['scan_options'])) {
 		$input_errors[] = "Scan option 'Log client hostnames' needs 'Reverse client ip lookups' to be selected as well.";
 	}
-	if (sizeof ($post['group_options']) > 0) {
+	if (is_array($post['group_options']) && sizeof ($post['group_options']) > 0) {
 		$_POST['lgroupoptions'] = implode (" ", $post['group_options']);
 	}
 	if ($post['banned_sitelist'] != "") {

--- a/pkg-e2guardian5/files/usr/local/pkg/e2guardian.inc
+++ b/pkg-e2guardian5/files/usr/local/pkg/e2guardian.inc
@@ -505,7 +505,9 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 	$loglevel = ($e2guardian_log['loglevel'] ? $e2guardian_log['loglevel'] : "2");
 	$logexceptionhits = ($e2guardian_log['logexceptionhits'] ? $e2guardian_log['logexceptionhits'] : "2");
 	$logfileformat = ($e2guardian_log['logfileformat'] ? $e2guardian_log['logfileformat'] : "1");
-	$logrotate = ($e2guardian_log['logrotate'] == "on" ? "on" : "off");
+	$logrotate = ($e2guardian_log['logrotate']  ? "on" : "off");
+	$cronminute = ($e2guardian_log['cronminute'] ? $e2guardian_log['cronminute'] : "*");
+	$cronhour = ($e2guardian_log['cronhour']  ? $e2guardian_log['cronhour'] : "*");
 	$logfilecount = ($e2guardian_log['logcount'] ? $e2guardian_log['logcount'] : "30");
 
 	
@@ -1527,7 +1529,7 @@ EOF;
 	$cron_cmd = "/usr/local/bin/php -q ${lrt_file}";
 	if ($logrotate == "on") {
         log_error("Log rotate on");
-		e2g_check_cron($cron_cmd, "create", "0", "0");
+		e2g_check_cron($cron_cmd, "create", $cronminute, $cronhour);
 	} else {
 		file_put_contents($lrt_file, "", LOCK_EX);
 		e2g_check_cron($cron_cmd, "remove");

--- a/pkg-e2guardian5/files/usr/local/pkg/e2guardian_log.xml
+++ b/pkg-e2guardian5/files/usr/local/pkg/e2guardian_log.xml
@@ -250,6 +250,18 @@
 			<fieldname>logrotate</fieldname>
 			<description><![CDATA[ Log File Rotation]]></description>
 			<type>checkbox</type>
+		</field>		
+        <field>
+			<fielddescr>Log Rotation Cron Minute</fielddescr>
+			<fieldname>cronminute</fieldname>
+			<description><![CDATA[ The minute(s) at the log rotation command will be executed. (0-59, ranges, or divided, *=all)]]></description>
+			<type>input</type>
+		</field>
+        <field>
+			<fielddescr>Log Rotation Cron Hour</fielddescr>
+			<fieldname>cronhour</fieldname>
+			<description><![CDATA[ The hour(s) at the log rotation command will be executed. (0-23, ranges, or divided, *=all)]]></description>
+			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Log File Count</fielddescr>


### PR DESCRIPTION
Crash report begins.  Anonymous machine information:

amd64
12.0-RELEASE-p3
FreeBSD 12.0-RELEASE-p3 da872a8c2a5(RELENG_2_5) pfSense

Crash report details:

PHP Errors:
[26-May-2019 05:04:16 Etc/GMT-3] PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/local/pkg/e2guardian.inc on line 1412
[26-May-2019 05:04:16 Etc/GMT-3] PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/local/pkg/e2guardian.inc on line 1413



No FreeBSD crash data found.
			 
is_countable -> https://www.php.net/manual/tr/function.is-countable.php with php 7